### PR TITLE
Parameterised aspects of the identicon

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@
 - Added parameter for background color
 - Added parameter for foreground color
 - Added parameter for corner radius
+- Added parameter for image type
 - Allowed dyanmic background color and static foreground color
 
 0.1.1

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@
 - Added parameter for foreground color
 - Added parameter for corner radius
 - Added parameter for image type
+- Color is now chosen using HLS (The Hue is varied, while lightness and saturation remains constant)
+- Added parameter for lightness
+- Added parameter for saturation
 - Allowed dyanmic background color and static foreground color
 
 0.1.1

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+0.2.0
+-----
+- Added parameter for image size
+- Added parameter for padding
+- Added parameter for background color
+- Added parameter for foreground color
+- Added parameter for corner radius
+- Allowed dyanmic background color and static foreground color
+
 0.1.1
 -----
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.2.0
 -----
+- Added parameter for input_hash_str (Allows the hash to be calculated via other means other than the default MD5)
 - Added parameter for image size
 - Added parameter for padding
 - Added parameter for background color

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -48,7 +48,7 @@ def _extract_color(hex_list):
     r,g,b =tuple(hex_list[i:i+2] 
             for i in range(0, 2*3, 2))
 
-    return f'#{r}{g}{b}'
+    return '#{r}{g}{b}'.format(r=r,g=g,b=b)
 
 def _build_grid(hex_list, number_of_blocks):
     # Tailing hex_list to rear 15 bytes

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding:utf-8 -*-
-__version__='0.2.0'
 
 import io
 import math

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -3,18 +3,35 @@ __version__='0.1.1'
 
 import io
 import hashlib
+import math
 from PIL import Image, ImageDraw
 
-BACKGROUND_COLOR = (244, 244, 244)
+DEFAULT_BACKGROUND_COLOR = (244, 244, 244)
+DEFAULT_PADDING = 20
+DEFAULT_SIZE = 290
 
-def render(code):
+def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, corner_radius=None):
+
+    # Generate colors
     hex_list = _to_hash_hex_list(code)
-    color = _extract_color(hex_list)
-    grid = _build_grid(hex_list)
-    flatten_grid = _flat_to_list(grid)
-    pixels = _set_pixels(flatten_grid)
-    identicon_im = _draw_identicon(color, flatten_grid, pixels)
+    generated_color = _extract_color(hex_list)
+    background_color = generated_color if background_color is None else background_color
+    foreground_color = generated_color if foreground_color is None else foreground_color
 
+    # Generate blocks
+    number_of_blocks = 5 # varying the number of blocks is currently unsupported
+    block_size = (size-2*padding)/number_of_blocks
+
+    grid = _build_grid(hex_list, number_of_blocks)
+    flatten_grid = _flat_to_list(grid)
+    pixels = _set_pixels(flatten_grid, number_of_blocks, block_size, padding)
+    identicon_im = _draw_identicon(background_color, foreground_color, size, flatten_grid, pixels)
+
+    # Add radius crop
+    if corner_radius is not None:
+        identicon_im = _crop_coner_round(identicon_im, corner_radius)
+
+    # Generate byte array
     identicon_byte_arr = io.BytesIO()
     identicon_im.save(identicon_byte_arr, format='PNG')
     identicon_byte_arr = identicon_byte_arr.getvalue()
@@ -33,31 +50,17 @@ def _extract_color(hex_list):
 
     return f'#{r}{g}{b}'
 
-def _set_pixels(flatten_grid):
-    # len(list) should be a squared of integer value
-    # Caculate pixels
-    pixels = []
-    for i, val in enumerate(flatten_grid):
-        x = int(i%5 * 50) + 20
-        y = int(i//5 * 50) + 20
-        
-        top_left = (x, y)
-        bottom_right = (x + 50, y + 50)
-        
-        pixels.append([top_left, bottom_right])
-
-    return pixels
-
-def _build_grid(hex_list):
+def _build_grid(hex_list, number_of_blocks):
     # Tailing hex_list to rear 15 bytes
     hex_list_tail = hex_list[2:]
     
     # Make 3x5 gird, half of the symmetric grid(left side)
-    hex_half_grid = [[hex_list_tail[col:col+2] for col in range(row, row+2*3, 2)] 
-            for row in range(0, 2*3*5, 2*3)]
+    half_number_of_blocks = math.ceil(number_of_blocks/2)
+    hex_half_grid = [[hex_list_tail[col:col+2] for col in range(row, row+2*half_number_of_blocks, 2)]
+            for row in range(0, 2*half_number_of_blocks*number_of_blocks, 2*half_number_of_blocks)]
 
     hex_grid = _mirror_row(hex_half_grid)
-    
+
     int_grid = [list(map(lambda e: int(e ,base=16), row)) for row in hex_grid]
 
     # TODO: Using more entropies, should be deprecated
@@ -77,14 +80,27 @@ def _flat_to_list(nested_list):
 
     return flatten_list
 
-def _draw_identicon(color, grid_list, pixels):
-    identicon_im = Image.new('RGB', (50*5+20*2, 50*5+20*2), BACKGROUND_COLOR)
+def _set_pixels(flatten_grid, number_of_blocks, block_size, padding):
+    # len(list) should be a squared of integer value
+    # Caculate pixels
+    pixels = []
+    for i, val in enumerate(flatten_grid):
+        x = int(i%number_of_blocks * block_size) + padding
+        y = int(i//number_of_blocks * block_size) + padding
+
+        top_left = (x, y)
+        bottom_right = (x + block_size, y + block_size)
+
+        pixels.append([top_left, bottom_right])
+
+    return pixels
+
+def _draw_identicon(background, foreground, size, grid_list, pixels):
+    identicon_im = Image.new('RGB', (size, size), background)
     draw = ImageDraw.Draw(identicon_im)
     for grid, pixel in zip(grid_list, pixels):
         if grid != 0: # for not zero
-            draw.rectangle(pixel, fill=color)
-
-    identicon_im = _crop_coner_round(identicon_im, 50)
+            draw.rectangle(pixel, fill=foreground)
 
     return identicon_im
 

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -55,7 +55,7 @@ def _build_grid(hex_list, number_of_blocks):
     hex_list_tail = hex_list[2:]
     
     # Make 3x5 gird, half of the symmetric grid(left side)
-    half_number_of_blocks = math.ceil(number_of_blocks/2)
+    half_number_of_blocks = int(math.ceil(number_of_blocks/2.0))
     hex_half_grid = [[hex_list_tail[col:col+2] for col in range(row, row+2*half_number_of_blocks, 2)]
             for row in range(0, 2*half_number_of_blocks*number_of_blocks, 2*half_number_of_blocks)]
 

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -9,8 +9,9 @@ from PIL import Image, ImageDraw
 DEFAULT_BACKGROUND_COLOR = (244, 244, 244)
 DEFAULT_PADDING = 20
 DEFAULT_SIZE = 290
+DEFAULT_IMAGE_TYPE = 'PNG'
 
-def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, corner_radius=None):
+def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
 
     # Generate colors
     hex_list = _to_hash_hex_list(code)
@@ -33,7 +34,7 @@ def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DE
 
     # Generate byte array
     identicon_byte_arr = io.BytesIO()
-    identicon_im.save(identicon_byte_arr, format='PNG')
+    identicon_im.save(identicon_byte_arr, format=image_type)
     identicon_byte_arr = identicon_byte_arr.getvalue()
 
     return identicon_byte_arr

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -11,12 +11,14 @@ DEFAULT_BACKGROUND_COLOR = (244, 244, 244)
 DEFAULT_PADDING = 20
 DEFAULT_SIZE = 290
 DEFAULT_IMAGE_TYPE = 'PNG'
+DEFAULT_LIGHTNESS = 0.5
+DEFAULT_SATURATION = 0.7
 
-def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
+def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, lightness=DEFAULT_LIGHTNESS, saturation=DEFAULT_SATURATION, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
 
     # Generate colors
     hex_list = _to_hash_hex_list(code)
-    generated_color = _extract_color(hex_list)
+    generated_color = _extract_color(hex_list, lightness, saturation)
     background_color = generated_color if background_color is None else background_color
     foreground_color = generated_color if foreground_color is None else foreground_color
 
@@ -46,7 +48,7 @@ def _to_hash_hex_list(code):
 
     return hash.hexdigest()
 
-def _extract_color(hex_list, saturation=0.7, lightness=0.5):
+def _extract_color(hex_list, lightness, saturation):
     hue = (int(hex_list[-7:], 16) / 0xfffffff)
 
     r,g,b = (int(round(v*255)) for v in colorsys.hls_to_rgb(hue, lightness, saturation))

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -49,7 +49,7 @@ def _to_hash_hex_str(input_str):
     return hash.hexdigest()
 
 def _extract_color(hex_list, lightness, saturation):
-    hue = (int(hex_list[-7:], 16) / 0xfffffff)
+    hue = (int(hex_list[-7:], 16) / float(0xfffffff))
 
     r,g,b = (int(v*255) for v in colorsys.hls_to_rgb(hue, lightness, saturation))
     return '#{:02x}{:02x}{:02x}'.format(r, g, b)

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -14,11 +14,11 @@ DEFAULT_IMAGE_TYPE = 'PNG'
 DEFAULT_LIGHTNESS = 0.5
 DEFAULT_SATURATION = 0.7
 
-def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, lightness=DEFAULT_LIGHTNESS, saturation=DEFAULT_SATURATION, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
+def render(input_str, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, lightness=DEFAULT_LIGHTNESS, saturation=DEFAULT_SATURATION, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
 
     # Generate colors
-    hex_list = _to_hash_hex_list(code)
-    generated_color = _extract_color(hex_list, lightness, saturation)
+    hex_str = _to_hash_hex_str(input_str)
+    generated_color = _extract_color(hex_str, lightness, saturation)
     background_color = generated_color if background_color is None else background_color
     foreground_color = generated_color if foreground_color is None else foreground_color
 
@@ -26,7 +26,7 @@ def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DE
     number_of_blocks = 5 # varying the number of blocks is currently unsupported
     block_size = (size-2*padding)/number_of_blocks
 
-    grid = _build_grid(hex_list, number_of_blocks)
+    grid = _build_grid(hex_str, number_of_blocks)
     flatten_grid = _flat_to_list(grid)
     pixels = _set_pixels(flatten_grid, number_of_blocks, block_size, padding)
     identicon_im = _draw_identicon(background_color, foreground_color, size, flatten_grid, pixels)
@@ -42,9 +42,9 @@ def render(code, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DE
 
     return identicon_byte_arr
 
-def _to_hash_hex_list(code):
+def _to_hash_hex_str(input_str):
     # TODO: Choose hash scheme
-    hash = hashlib.md5(code.encode('utf8'))
+    hash = hashlib.md5(input_str.encode('utf8'))
 
     return hash.hexdigest()
 

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -48,19 +48,19 @@ def _to_hash_hex_str(input_str):
 
     return hash.hexdigest()
 
-def _extract_color(hex_list, lightness, saturation):
-    hue = (int(hex_list[-7:], 16) / float(0xfffffff))
+def _extract_color(hex_str, lightness, saturation):
+    hue = (int(hex_str[-7:], 16) / float(0xfffffff))
 
     r,g,b = (int(v*255) for v in colorsys.hls_to_rgb(hue, lightness, saturation))
     return '#{:02x}{:02x}{:02x}'.format(r, g, b)
 
-def _build_grid(hex_list, number_of_blocks):
-    # Tailing hex_list to rear 15 bytes
-    hex_list_tail = hex_list[2:]
+def _build_grid(hex_str, number_of_blocks):
+    # Tailing hex_str to rear 15 bytes
+    hex_str_tail = hex_str[2:]
     
     # Make 3x5 gird, half of the symmetric grid(left side)
     half_number_of_blocks = int(math.ceil(number_of_blocks/2.0))
-    hex_half_grid = [[hex_list_tail[col:col+2] for col in range(row, row+2*half_number_of_blocks, 2)]
+    hex_half_grid = [[hex_str_tail[col:col+2] for col in range(row, row+2*half_number_of_blocks, 2)]
             for row in range(0, 2*half_number_of_blocks*number_of_blocks, 2*half_number_of_blocks)]
 
     hex_grid = _mirror_row(hex_half_grid)

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -14,10 +14,10 @@ DEFAULT_IMAGE_TYPE = 'PNG'
 DEFAULT_LIGHTNESS = 0.5
 DEFAULT_SATURATION = 0.7
 
-def render(input_str, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, lightness=DEFAULT_LIGHTNESS, saturation=DEFAULT_SATURATION, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
+def render(input_str, input_hash_str=None, size=DEFAULT_SIZE, padding=DEFAULT_PADDING, background_color=DEFAULT_BACKGROUND_COLOR, foreground_color=None, lightness=DEFAULT_LIGHTNESS, saturation=DEFAULT_SATURATION, corner_radius=None, image_type=DEFAULT_IMAGE_TYPE):
 
     # Generate colors
-    hex_str = _to_hash_hex_str(input_str)
+    hex_str = input_hash_str if input_hash_str else _to_hash_hex_str(input_str)
     generated_color = _extract_color(hex_str, lightness, saturation)
     background_color = generated_color if background_color is None else background_color
     foreground_color = generated_color if foreground_color is None else foreground_color

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding:utf-8 -*-
-__version__='0.1.1'
+__version__='0.2.0'
 
 import io
 import hashlib

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -2,8 +2,9 @@
 __version__='0.2.0'
 
 import io
-import hashlib
 import math
+import hashlib
+import colorsys
 from PIL import Image, ImageDraw
 
 DEFAULT_BACKGROUND_COLOR = (244, 244, 244)
@@ -45,11 +46,11 @@ def _to_hash_hex_list(code):
 
     return hash.hexdigest()
 
-def _extract_color(hex_list):
-    r,g,b =tuple(hex_list[i:i+2] 
-            for i in range(0, 2*3, 2))
+def _extract_color(hex_list, saturation=0.7, lightness=0.5):
+    hue = (int(hex_list[-7:], 16) / 0xfffffff)
 
-    return '#{r}{g}{b}'.format(r=r,g=g,b=b)
+    r,g,b = (int(round(v*255)) for v in colorsys.hls_to_rgb(hue, lightness, saturation))
+    return '#{:02x}{:02x}{:02x}'.format(r, g, b)
 
 def _build_grid(hex_list, number_of_blocks):
     # Tailing hex_list to rear 15 bytes

--- a/Identicon/__init__.py
+++ b/Identicon/__init__.py
@@ -51,7 +51,7 @@ def _to_hash_hex_list(code):
 def _extract_color(hex_list, lightness, saturation):
     hue = (int(hex_list[-7:], 16) / 0xfffffff)
 
-    r,g,b = (int(round(v*255)) for v in colorsys.hls_to_rgb(hue, lightness, saturation))
+    r,g,b = (int(v*255) for v in colorsys.hls_to_rgb(hue, lightness, saturation))
     return '#{:02x}{:02x}{:02x}'.format(r, g, b)
 
 def _build_grid(hex_list, number_of_blocks):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 from os.path import isfile
 
-import Identicon
-
 def read(*names):
     values = dict()
     extensions = ['.txt', '.rst']
@@ -25,7 +23,7 @@ long_description = '''
 
 setup(
     name='Identicon',
-    version=Identicon.__version__,
+    version='0.2.0',
     description='A Python library for generating Github-like identicons',
     long_description=long_description,
     keywords='identicon image profile render github',

--- a/tests.py
+++ b/tests.py
@@ -16,12 +16,12 @@ class IdenticonTestCase(unittest.TestCase):
         return ''.join(random.choices(string.printable, k=n))
 
     # Tests
-    def test_to_hash_hex_list_return_32bytes(self):
-        self.assertEqual(len(Identicon._to_hash_hex_list('some_code')), 32)
-        self.assertEqual(len(Identicon._to_hash_hex_list('other_code')), 32)
+    def test_to_hash_hex_str_return_32bytes(self):
+        self.assertEqual(len(Identicon._to_hash_hex_str('some_code')), 32)
+        self.assertEqual(len(Identicon._to_hash_hex_str('other_code')), 32)
 
     def test_extract_color_return_hex_rgb_string(self):
-        hex_list = Identicon._to_hash_hex_list('test_extract_color')
+        hex_list = Identicon._to_hash_hex_str('test_extract_color')
 
         self.assertRegex(Identicon._extract_color(hex_list, 0.5, 0.7), r'^#[0-9a-fA-F]{6}$')
 

--- a/tests.py
+++ b/tests.py
@@ -23,7 +23,7 @@ class IdenticonTestCase(unittest.TestCase):
     def test_extract_color_return_hex_rgb_string(self):
         hex_list = Identicon._to_hash_hex_list('test_extract_color')
 
-        self.assertRegex(Identicon._extract_color(hex_list), r'^#[0-9a-fA-F]{6}$')
+        self.assertRegex(Identicon._extract_color(hex_list, 0.5, 0.7), r'^#[0-9a-fA-F]{6}$')
 
     def test_build_grid_return_5x5_list(self):
         #dummy_hex_list = str(0x0123456789abcdef) 

--- a/tests.py
+++ b/tests.py
@@ -29,7 +29,7 @@ class IdenticonTestCase(unittest.TestCase):
         #dummy_hex_list = str(0x0123456789abcdef) 
         dummy_hex_list = hashlib.md5('dummy'.encode('utf8')).hexdigest()
         
-        grid = Identicon._build_grid(dummy_hex_list)
+        grid = Identicon._build_grid(dummy_hex_list, 5)
 
         self.assertEqual(len(grid), 5)
         for i in range(5):
@@ -64,7 +64,7 @@ class IdenticonTestCase(unittest.TestCase):
        rgb_image = image.convert('RGB')
        background_color = rgb_image.getpixel((19,19))
 
-       self.assertEqual(Identicon.BACKGROUND_COLOR, background_color)
+       self.assertEqual(Identicon.DEFAULT_BACKGROUND_COLOR, background_color)
 
 
 


### PR DESCRIPTION
Implemented parameters for input_hash_str, image size, padding, background colour, foreground colour, corner radius , lightness, saturation and image type.

input_hash_str allows directly inserting a hash, which allows for other possibilities other than MD5 

Background colour and foreground colour can now be set to static colours, or if they are set to None the dynamic colour will be used. This means the foreground can be white and the background can have a dynamic colour instead.

The dynamic colour is now generated using HLS, in the same manner as http://identicon.net. This gives a more consistent look to the generated Identicons. Not sure if your happy accepting the new colour generating algorithm, although it does appear to produce better results.

All the defaults remain the same except for the border_radius it defaults to None. It seemed the most appropriate thing to do.

The motivator for these changes, was that I needed to create a GitHub-esque Identicon, which would be circle cropped (When displayed in a list view, but square when viewed in full). Hence I needed to be able to adjust the padding, such that it looked good when circle cropped. Along with removing the post-process corner radius, and flipping the dynamic colours. Obviously changing the size of the image was also relevant.

This is the code I used to achieve the above.
```

import math
import base64
import Identicon

size = 192
minimum_padding = (size-math.sqrt(math.pow(size, 2)/2))/2
padding = minimum_padding + 20

icon = Identicon.render('helloworld', size=size, padding=padding, background_color=None, foreground_color=(255,255,255))

print(base64.b64encode(icon))
with open('identicon.png', 'wb') as f:
    f.write(icon)
```