### PR TITLE
Make it installable as Requirement with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 from os.path import isfile
 
-import Identicon
-
 def read(*names):
     values = dict()
     extensions = ['.txt', '.rst']
@@ -25,7 +23,7 @@ long_description = '''
 
 setup(
     name='Identicon',
-    version=Identicon.__version__,
+    version='0.1',
     description='A Python library for generating Github-like identicons',
     long_description=long_description,
     keywords='identicon image profile render github',


### PR DESCRIPTION
Problem: Pip has 2 steps:
(1) Iterate over all Requirements and *run setup.py*
(2) install all Requirements
Problem: If you import your own package, which in turn has other Requirements, then install fails, because the Requirements are not yet met.